### PR TITLE
Fix dependencies and bump Standards-Version (Debian bug #820686)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libu2f-host (1.0.0-2+nmu1) unstable; urgency=medium
+
+  * Fix dependencies (libjson & glib2.0) (Closes: 820686).
+  * Non-maintainer upload.
+
+ -- Nicolas Braud-Santoni <nicolas@braud-santoni.eu>  Wed, 01 Jun 2016 23:55:05 +0200
+
 libu2f-host (1.0.0-2) UNRELEASED; urgency=low
 
   * Add gbp.conf.

--- a/debian/control
+++ b/debian/control
@@ -5,14 +5,15 @@ Section: utils
 Priority: extra
 Build-Depends: debhelper (>= 9),
 	       pkg-config,
+	       libglib2.0-dev,
 	       libhidapi-dev,
-	       libjson0-dev,
+	       libjson-c-dev,
 	       gengetopt,
 	       help2man,
 	       dh-autoreconf,
 	       gtk-doc-tools,
 	       dblatex
-Standards-Version: 3.9.6
+Standards-Version: 3.9.8
 Homepage: https://developers.yubico.com/libu2f-host/
 Vcs-Git: git://github.com/Yubico/libu2f-host-dpkg.git
 Vcs-Browser: https://github.com/Yubico/libu2f-host-dpkg

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/pkg-info.mk
+
 %:
 	dh $@ --parallel --with autoreconf
 
@@ -16,3 +18,10 @@ override_dh_auto_clean:
 
 override_dh_compress:
 	dh_compress -Xu2f-host.pdf
+
+
+gen-orig-source:
+	git archive --format=tar.gz                                     \
+		--prefix=$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)/         \
+		upstream/$(subst ~,_,$(DEB_VERSION_UPSTREAM))           \
+		-o ../$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,1 +1,1 @@
-extend-diff-ignore="gtk-doc/tmpl/u2f-host-types.sgml|gtk-doc/tmpl/u2f-host-version.sgml|gtk-doc/tmpl/u2f-host.sgml"
+extend-diff-ignore="gtk-doc/tmpl/u2f-host-types.sgml|gtk-doc/tmpl/u2f-host-version.sgml|gtk-doc/tmpl/u2f-host.sgml|gtk-doc/html/*.html|gtk-doc/u2f-host.pdf"


### PR DESCRIPTION
I somehow didn't notice this repo and sent the patch to the Debian BTS in [bug #820686](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=820686).

Given the complete lack of follow-up, both on [the other PR](https://github.com/Yubico/libu2f-server-dpkg/pull/1) and in the BTS, I will request a sponsored NMU (non-maintainer upload) to get the fixed version in the Debian archive.
